### PR TITLE
Fix a Validation Issue for the Card Holder Name

### DIFF
--- a/src/components/CreditCardForm.tsx
+++ b/src/components/CreditCardForm.tsx
@@ -147,12 +147,12 @@ const CreditCardForm: React.FC<LibraryProps> = (props) => {
             name="holderName"
             label={translations.cardHolderName}
             rules={{
-              required: translations.cardNumberRequired,
+              required: translations.cardHolderNameRequired,
               validate: {
                 isValid: (value: string) => {
                   return (
                     cardValidator.cardholderName(value).isValid ||
-                    translations.cardNumberInvalid
+                    translations.cardHolderNameInvalid
                   )
                 },
               },


### PR DESCRIPTION
**ISSUE TO BE FIXED**
Whenever attempted to skip the cardholder's name without providing any value, a validation message for card number is required/card number is invalid was being displayed instead of cardholder's name is required/cardholder's name is invalid. So, I have fixed the issue to display the corresponding validation error messages for the cardholder's name text field.